### PR TITLE
Loading container fix

### DIFF
--- a/src/features/loader/Loader.tsx
+++ b/src/features/loader/Loader.tsx
@@ -52,6 +52,7 @@ const LoadingContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  ${props => props.className}
 `
 
 const AdaptiveLoader: FC<Props> = React.memo(


### PR DESCRIPTION
So forgot to add ${props => props.className} to my loading container styled div.

Now the LoadingContainer can have it's styled extended through the className prop.

I done this to allow for some positioning styles that were unique to each component.

I won't need to do this once I have implemented CSS grid as my highest level.